### PR TITLE
Send input fixes

### DIFF
--- a/src/lib/components/button/button.svelte
+++ b/src/lib/components/button/button.svelte
@@ -25,7 +25,6 @@
 		data-active={props.active}
 		class="
 		relative
-		m-0.5
 		inline-block
 		text-nowrap
 		rounded-full
@@ -61,7 +60,7 @@
 		disabled={props.disabled}
 		class="
 		relative
-		m-0.5
+		grow
 		text-nowrap
 		rounded-lg
 		px-8
@@ -72,6 +71,7 @@
 		ring-2
 		ring-inset
 		ring-mineShaft-600
+		transition-all
 
 		focus-visible:outline
 		focus-visible:outline-transparent
@@ -101,7 +101,7 @@
 		disabled={props.disabled}
 		class="
 		relative
-		m-0.5
+		grow
 		text-nowrap
 		rounded-lg
 		bg-skyBlue-500
@@ -110,6 +110,7 @@
 		text-base
 		font-medium
 		text-skyBlue-950
+		transition-all
 
 		focus:outline-transparent
 		focus-visible:outline

--- a/src/lib/components/input/asset.svelte
+++ b/src/lib/components/input/asset.svelte
@@ -106,7 +106,14 @@
 		});
 </script>
 
-<TextInput bind:ref bind:value={input} placeholder={zeroValue.quantity} {autofocus} {...props} />
+<TextInput
+	bind:ref
+	bind:value={input}
+	placeholder={zeroValue.quantity}
+	{autofocus}
+	type="number"
+	{...props}
+/>
 
 {#if debug}
 	<h3>Component State</h3>

--- a/src/lib/components/input/asset.svelte
+++ b/src/lib/components/input/asset.svelte
@@ -111,7 +111,7 @@
 	bind:value={input}
 	placeholder={zeroValue.quantity}
 	{autofocus}
-	type="number"
+	inputmode="numeric"
 	{...props}
 />
 

--- a/src/lib/components/input/asset.svelte
+++ b/src/lib/components/input/asset.svelte
@@ -19,7 +19,8 @@
 		ref = $bindable(),
 		valid = $bindable(false),
 		value: _value = $bindable(),
-		debug = false
+		debug = false,
+		...props
 	}: AssetInputProps = $props();
 
 	/** A zero-value version of the passed in asset for placeholder */
@@ -105,7 +106,7 @@
 		});
 </script>
 
-<TextInput bind:ref bind:value={input} placeholder={zeroValue.quantity} {autofocus} />
+<TextInput bind:ref bind:value={input} placeholder={zeroValue.quantity} {autofocus} {...props} />
 
 {#if debug}
 	<h3>Component State</h3>

--- a/src/lib/components/input/name.svelte
+++ b/src/lib/components/input/name.svelte
@@ -14,7 +14,8 @@
 		ref = $bindable(),
 		valid = $bindable(false),
 		value: _value = $bindable(),
-		debug = false
+		debug = false,
+		...props
 	}: NameInputProps = $props();
 
 	/** The string value bound to the form input */
@@ -52,7 +53,7 @@
 		});
 </script>
 
-<TextInput bind:ref bind:value={input} {autofocus} />
+<TextInput bind:ref bind:value={input} {autofocus} {...props} />
 
 {#if debug}
 	<h3>Component State</h3>

--- a/src/lib/components/input/textinput.svelte
+++ b/src/lib/components/input/textinput.svelte
@@ -5,12 +5,17 @@
 		ref?: HTMLInputElement;
 	}
 
-	let { ref = $bindable(), value = $bindable(), ...props }: TextInputProps = $props();
+	let {
+		ref = $bindable(),
+		value = $bindable(),
+		type = 'text',
+		...props
+	}: TextInputProps = $props();
 </script>
 
 <input
 	class="rounded-lg bg-transparent px-4 py-4 font-medium outline outline-1 outline-gray-700 focus:outline-none focus:ring focus:ring-inset focus:ring-blue-500"
-	type="text"
+	{type}
 	bind:this={ref}
 	bind:value
 	{...props}

--- a/src/lib/components/input/textinput.svelte
+++ b/src/lib/components/input/textinput.svelte
@@ -1,5 +1,11 @@
 <script lang="ts">
-	let { ref = $bindable(), value = $bindable(), ...props } = $props();
+	import type { HTMLInputAttributes } from 'svelte/elements';
+
+	interface TextInputProps extends HTMLInputAttributes {
+		ref?: HTMLInputElement;
+	}
+
+	let { ref = $bindable(), value = $bindable(), ...props }: TextInputProps = $props();
 </script>
 
 <input

--- a/src/lib/components/input/textinput.svelte
+++ b/src/lib/components/input/textinput.svelte
@@ -5,17 +5,12 @@
 		ref?: HTMLInputElement;
 	}
 
-	let {
-		ref = $bindable(),
-		value = $bindable(),
-		type = 'text',
-		...props
-	}: TextInputProps = $props();
+	let { ref = $bindable(), value = $bindable(), ...props }: TextInputProps = $props();
 </script>
 
 <input
 	class="rounded-lg bg-transparent px-4 py-4 font-medium outline outline-1 outline-gray-700 focus:outline-none focus:ring focus:ring-inset focus:ring-blue-500"
-	{type}
+	type="text"
 	bind:this={ref}
 	bind:value
 	{...props}

--- a/src/lib/components/pageheader.svelte
+++ b/src/lib/components/pageheader.svelte
@@ -1,0 +1,15 @@
+<script lang="ts">
+	interface Props {
+		title: string;
+		subtitle?: string;
+		inverted?: boolean;
+	}
+	let props: Props = $props();
+</script>
+
+<header class="flex gap-2" class:flex-col={!props.inverted} class:flex-col-reverse={props.inverted}>
+	<h1 class="text-3xl font-bold leading-none text-white">{props.title}</h1>
+	{#if props.subtitle}
+		<h2 class="text-xl font-medium leading-none text-white/60">{props.subtitle}</h2>
+	{/if}
+</header>

--- a/src/lib/components/progress.svelte
+++ b/src/lib/components/progress.svelte
@@ -7,7 +7,7 @@
 		<div
 			data-complete={step < currentStep - 1}
 			data-current={step === currentStep - 1}
-			class="step-{step} my-8 h-1 flex-1 rounded-full border-0 bg-white/10 data-[complete=true]:bg-white data-[current=true]:bg-white"
+			class="step-{step} h-1 flex-1 rounded-full border-0 bg-white/10 data-[complete=true]:bg-white data-[current=true]:bg-white"
 		></div>
 	{/each}
 </div>

--- a/src/routes/[network]/(dev)/debug/components/sections/typography.svelte
+++ b/src/routes/[network]/(dev)/debug/components/sections/typography.svelte
@@ -1,5 +1,6 @@
 <script>
 	import { Cluster, Stack } from '$lib/components/layout';
+	import PageHeader from '$lib/components/pageheader.svelte';
 </script>
 
 <Stack id="typography">
@@ -14,23 +15,23 @@
 		heading. This is easily achieved by applying the h2 class to the h1 tag.
 	</p>
 	<Cluster class="items-center">
-		<h1 class="h1">Heading 1 (Inter 48)</h1>
+		<p class="h1">Heading 1 (Inter 48)</p>
 		<code class=" rounded-lg bg-gray-300 p-2 text-black">class='h1'</code>
 	</Cluster>
 	<Cluster class="items-center">
-		<h2 class="h2">Heading 2 (Inter 32)</h2>
+		<p class="h2">Heading 2 (Inter 32)</p>
 		<code class=" rounded-lg bg-gray-300 p-2 text-black">class='h2'</code>
 	</Cluster>
 	<Cluster class="items-center">
-		<h3 class="h3">Heading 3 (Inter 24)</h3>
+		<p class="h3">Heading 3 (Inter 24)</p>
 		<code class=" rounded-lg bg-gray-300 p-2 text-black">class='h3'</code>
 	</Cluster>
 	<Cluster class="items-center">
-		<h4 class="h4">Heading 4 (Inter 18)</h4>
+		<p class="h4">Heading 4 (Inter 18)</p>
 		<code class=" rounded-lg bg-gray-300 p-2 text-black">class='h4'</code>
 	</Cluster>
 	<Cluster class="items-center">
-		<h5 class="h5">Heading 5 (Inter 16)</h5>
+		<p class="h5">Heading 5 (Inter 16)</p>
 		<code class="rounded-lg bg-gray-300 p-2 text-black">class='h5'</code>
 	</Cluster>
 	<Cluster class="items-center">
@@ -44,4 +45,10 @@
 		in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
 		cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
 	</p>
+</Stack>
+
+<Stack class="gap-8">
+	<h2 class="h2">Page Header</h2>
+	<PageHeader title="Send" subtitle="Add recipient" />
+	<PageHeader title="teamgreymass" subtitle="Account" inverted />
 </Stack>


### PR DESCRIPTION
Fixes input props and correctly passes HTMLInputAttributes (e.g. `id`) to the root component
Changes Asset component to use `type=number` for the number keyboard on mobile
Adds PageHeader component for consistent cross-page styling
Adds some additional styling and layout to the Send page
Fixes an issue with buttons in a flex context
Adds an animation on the Send page buttons