### PR TITLE
Adding initial settings concept

### DIFF
--- a/src/lib/state/settings.svelte.ts
+++ b/src/lib/state/settings.svelte.ts
@@ -1,0 +1,32 @@
+import { browser } from '$app/environment';
+
+export class SettingState<T> {
+	value = $state<T>() as T;
+	key = '';
+
+	constructor(key: string, value: T) {
+		this.key = key;
+		this.value = value;
+
+		if (browser) {
+			const item = localStorage.getItem(key);
+			if (item) this.value = this.deserialize(item);
+		}
+
+		$effect(() => {
+			localStorage.setItem(this.key, this.serialize(this.value));
+		});
+	}
+
+	serialize(value: T): string {
+		return JSON.stringify(value);
+	}
+
+	deserialize(item: string): T {
+		return JSON.parse(item);
+	}
+}
+
+export function getSetting<T>(key: string, value: T) {
+	return new SettingState(key, value);
+}

--- a/src/routes/[network]/(account)/(send)/send/+page.svelte
+++ b/src/routes/[network]/(account)/(send)/send/+page.svelte
@@ -19,6 +19,10 @@
 	import { SendState } from './state.svelte';
 	import { page } from '$app/stores';
 
+	import { getSetting } from '$lib/state/settings.svelte';
+
+	const debugMode = getSetting('debug-mode', false);
+
 	const context = getContext<UnicoveContext>('state');
 	const { data } = $props();
 	const state: SendState = $state(new SendState(data.network.chain));
@@ -246,13 +250,15 @@
 		</fieldset>
 	</form>
 
-	<h3 class="h3">Debugging</h3>
-	<Code
-		>{JSON.stringify(
-			{ state, current: f.current, valid: { toValid, assetValid, memoValid } },
-			undefined,
-			2
-		)}</Code
-	>
+	{#if debugMode.value}
+		<h3 class="h3">Debugging</h3>
+		<Code
+			>{JSON.stringify(
+				{ state, current: f.current, valid: { toValid, assetValid, memoValid } },
+				undefined,
+				2
+			)}</Code
+		>
+	{/if}
 	<Button onclick={() => f.send('reset')}>Reset</Button>
 </article>

--- a/src/routes/[network]/settings/+page.svelte
+++ b/src/routes/[network]/settings/+page.svelte
@@ -1,0 +1,30 @@
+<script lang="ts">
+	import LanguageSelect from '$lib/components/select/language.svelte';
+	import { getSetting } from '$lib/state/settings.svelte';
+
+	let advancedMode = getSetting('advanced-mode', false);
+	let debugMode = getSetting('debug-mode', false);
+
+	function toggleAdvanced() {
+		// Toggle the advanced mode
+		advancedMode.value = !advancedMode.value;
+
+		// If disabling advanced, also disable any advanced settings that may be on
+		if (!advancedMode.value) {
+			debugMode.value = false;
+		}
+	}
+</script>
+
+<p>Language Selector</p>
+<LanguageSelect />
+
+<label for="advanced-mode"> Enable Advanced Mode </label>
+<input id="advanced-mode" type="checkbox" checked={advancedMode.value} on:change={toggleAdvanced} />
+
+{#if advancedMode.value}
+	<div>
+		<label for="debug-mode"> Enable Debug Mode </label>
+		<input id="debug-mode" type="checkbox" bind:checked={debugMode.value} />
+	</div>
+{/if}


### PR DESCRIPTION
Adds the `/settings` page, which contains:

- Language switcher
- Enable Advanced mode
- Enable Debug mode

Then altered the `/send` page to only display debugging information if the debug mode setting is true.