### PR TITLE
refactor: use index in token select value

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -23,7 +23,10 @@ export default [
 		files: ['**/*.svelte'],
 		languageOptions: {
 			parserOptions: {
-				parser: ts.parser
+				parser: ts.parser,
+				svelteFeatures: {
+					experimentalGenerics: true
+				}
 			}
 		}
 	},

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -23,10 +23,7 @@ export default [
 		files: ['**/*.svelte'],
 		languageOptions: {
 			parserOptions: {
-				parser: ts.parser,
-				svelteFeatures: {
-					experimentalGenerics: true
-				}
+				parser: ts.parser
 			}
 		}
 	},

--- a/src/lib/components/chart/rampricehistory.svelte
+++ b/src/lib/components/chart/rampricehistory.svelte
@@ -22,20 +22,20 @@
 	let ctx: HTMLCanvasElement;
 	let chart: Chart<'line'>;
 
-	const range: CustomSelectOption[] = [
+	const range: CustomSelectOption<number>[] = [
 		{ label: '1D', value: 1 },
 		{ label: '1W', value: 7 },
 		{ label: '1M', value: 30 },
 		{ label: '1Y', value: 365 }
 	];
 
-	let selectedRange: CustomSelectOption = $state(range[1]);
+	let selectedRange: CustomSelectOption<number> = $state(range[1]);
 
 	let dataRange = $derived.by(() => {
 		if (!data || data.length === 0) return [];
 		const rangeEndDate = dayjs(data[0].date);
 		const rangeStartDate = rangeEndDate.subtract(Number(selectedRange.value), 'day');
-		debug && $inspect({ rangeStartDate, rangeEndDate });
+		if (debug) $inspect({ rangeStartDate, rangeEndDate });
 		return data.filter(({ date }) => dayjs(date).isAfter(rangeStartDate));
 	});
 
@@ -115,8 +115,9 @@
 		chart.update();
 	});
 
-	debug &&
+	if (debug) {
 		$inspect({ dataRangeLength: dataRange.length, currentDate: currentPoint?.date, percentChange });
+	}
 </script>
 
 <Card>

--- a/src/lib/components/chart/rampricehistory.svelte
+++ b/src/lib/components/chart/rampricehistory.svelte
@@ -8,7 +8,8 @@
 	import 'chart.js/auto';
 	import { Card, Stack } from '$lib/components/layout';
 	import { Asset } from '@wharfkit/antelope';
-	import Select, { type CustomSelectOption } from '../select/select.svelte';
+	import Select from '../select/select.svelte';
+	import type { ExtendedSelectOption } from '../select/types';
 
 	interface Props {
 		data: { date: Date; value: Asset }[];
@@ -22,14 +23,14 @@
 	let ctx: HTMLCanvasElement;
 	let chart: Chart<'line'>;
 
-	const range: CustomSelectOption<number>[] = [
+	const range: ExtendedSelectOption[] = [
 		{ label: '1D', value: 1 },
 		{ label: '1W', value: 7 },
 		{ label: '1M', value: 30 },
 		{ label: '1Y', value: 365 }
 	];
 
-	let selectedRange: CustomSelectOption<number> = $state(range[1]);
+	let selectedRange: ExtendedSelectOption = $state(range[1]);
 
 	let dataRange = $derived.by(() => {
 		if (!data || data.length === 0) return [];
@@ -100,10 +101,6 @@
 					legend: {
 						display: false
 					}
-					// decimation: {
-					// 	enabled: true,
-					// 	algorithm: 'lttb'
-					// }
 				}
 			}
 		});

--- a/src/lib/components/select/elements/index.ts
+++ b/src/lib/components/select/elements/index.ts
@@ -1,0 +1,3 @@
+export { default as SelectMenu } from './menu.svelte';
+export { default as SelectTrigger } from './trigger.svelte';
+export { default as SelectItem } from './item.svelte';

--- a/src/lib/components/select/elements/item.svelte
+++ b/src/lib/components/select/elements/item.svelte
@@ -1,0 +1,53 @@
+<script lang="ts">
+	import { melt } from '@melt-ui/svelte';
+	import { Check } from 'lucide-svelte';
+	import type { Readable } from 'svelte/store';
+	import type { ExtendedSelectOption } from '../types';
+
+	interface Props {
+		variant?: 'pill' | 'form';
+		id: string;
+		// Upstream bug: https://github.com/melt-ui/melt-ui/issues/974
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		option: any;
+		item: ExtendedSelectOption;
+		isSelected: Readable<(value: unknown) => boolean>;
+	}
+
+	const { option, isSelected, ...props }: Props = $props();
+</script>
+
+<div
+	class="
+	relative
+	grid
+	cursor-pointer
+	grid-cols-[16px_1fr]
+	items-center
+	gap-2
+	rounded-xl
+	px-2
+	py-1
+	font-medium
+	hover:bg-solar-500
+	hover:text-black/95
+	focus:z-10
+	focus:text-solar-950
+	data-[variant=form]:rounded-sm
+	data-[variant=pill]:rounded-xl
+	data-[highlighted=true]:bg-solar-500
+	data-[highlighted=true]:text-solar-950
+	data-[disabled]:opacity-50
+	"
+	data-variant={props.variant}
+	use:melt={$option(props.item)}
+>
+	{#if props.item.image && typeof props.item.image === 'string'}
+		<img src={props.item.image} alt={props.item.label} class="mr-2 size-4 object-contain" />
+	{:else}
+		<div class="check">
+			<Check class="size-4 {$isSelected(props.item.value) ? 'block' : 'hidden'}" />
+		</div>
+	{/if}
+	{props.item.label}
+</div>

--- a/src/lib/components/select/elements/menu.svelte
+++ b/src/lib/components/select/elements/menu.svelte
@@ -1,0 +1,45 @@
+<script lang="ts">
+	import { type AnyMeltElement, melt } from '@melt-ui/svelte';
+	import { type Snippet } from 'svelte';
+	import type { Readable } from 'svelte/store';
+	import { fade } from 'svelte/transition';
+	interface Props {
+		variant: 'pill' | 'form';
+		id: string;
+		children: Snippet;
+		open: Readable<boolean>;
+		menu: AnyMeltElement;
+	}
+
+	const { menu, ...props }: Props = $props();
+</script>
+
+{#if props.open}
+	<div
+		class="
+		z-10
+		flex
+		max-h-[300px]
+		flex-col
+		overflow-y-auto
+		border-2
+		border-mineShaft-600
+		bg-shark-950
+		py-1
+		shadow
+		focus:!ring-0
+		data-[variant=form]:rounded-lg
+		data-[variant=pill]:rounded-2xl
+		data-[variant=form]:px-2
+		data-[variant=form]:py-2
+		data-[variant=pill]:px-1
+		data-[variant=pill]:py-1
+		"
+		data-variant={props.variant}
+		use:melt={$menu}
+		transition:fade={{ duration: 100 }}
+		id={props.id + '-menu'}
+	>
+		{@render props.children()}
+	</div>
+{/if}

--- a/src/lib/components/select/elements/trigger.svelte
+++ b/src/lib/components/select/elements/trigger.svelte
@@ -1,0 +1,53 @@
+<script lang="ts">
+	import { type AnyMeltElement, melt } from '@melt-ui/svelte';
+	import { ChevronDown } from 'lucide-svelte';
+	import { type Snippet } from 'svelte';
+	import { type Readable } from 'svelte/store';
+
+	interface Props {
+		variant?: 'pill' | 'form';
+		id: string;
+		children: Snippet;
+		open: Readable<boolean>;
+		trigger: AnyMeltElement;
+	}
+
+	const { trigger, open, ...props }: Props = $props();
+</script>
+
+<button
+	class="
+	flex
+	items-center
+	justify-between
+	gap-2
+	border-2
+	border-mineShaft-600
+	bg-transparent
+	pl-4
+	pr-3
+	font-medium
+	transition-opacity
+	hover:opacity-90
+	focus:outline-2
+	focus:outline-solar-500
+	focus-visible:border-transparent
+	focus-visible:outline
+	data-[variant=pill]:h-10
+	data-[variant=form]:rounded-lg
+	data-[variant=pill]:rounded-full
+	data-[variant=form]:py-4
+	"
+	data-variant={props.variant}
+	use:melt={$trigger}
+	aria-label="{props.id}-label"
+	id={props.id}
+>
+	<div class="flex items-center">
+		{@render props.children()}
+	</div>
+	<ChevronDown
+		data-open={$open}
+		class="size-5 transition-transform duration-100 data-[open=true]:rotate-180"
+	/>
+</button>

--- a/src/lib/components/select/select.svelte
+++ b/src/lib/components/select/select.svelte
@@ -1,22 +1,14 @@
-<script lang="ts" context="module">
-	import { type SelectOption } from '@melt-ui/svelte';
-	export interface CustomSelectOption<T = unknown> extends SelectOption<T> {
-		image?: string;
-	}
-</script>
-
-<script lang="ts" generics="T extends unknown">
-	import { createSelect, createSync, melt } from '@melt-ui/svelte';
-	import { fade } from 'svelte/transition';
-	import Check from 'lucide-svelte/icons/check';
-	import ChevronDown from 'lucide-svelte/icons/chevron-down';
+<script lang="ts">
+	import { createSelect, createSync } from '@melt-ui/svelte';
 	import type { ChangeFn } from '@melt-ui/svelte/internal/helpers';
+	import { SelectTrigger, SelectMenu, SelectItem } from './elements';
+	import type { ExtendedSelectOption, SelectOptionVariant } from './types';
 
 	interface Props {
-		options: CustomSelectOption<T>[];
-		selected: CustomSelectOption<T>;
-		onSelectedChange?: ChangeFn<CustomSelectOption<T> | undefined>;
-		variant?: 'pill' | 'form';
+		options: ExtendedSelectOption[];
+		selected: ExtendedSelectOption;
+		onSelectedChange?: ChangeFn<ExtendedSelectOption | undefined>;
+		variant?: SelectOptionVariant;
 		id: string;
 		required?: boolean;
 		disabled?: boolean;
@@ -41,7 +33,6 @@
 		states: { open, selected, selectedLabel },
 		helpers: { isSelected }
 	} = createSelect({
-		defaultSelected: _selected || options[0],
 		onSelectedChange,
 		required,
 		disabled,
@@ -54,120 +45,29 @@
 		}
 	});
 
+	// Sync the selected option with the passed in selected prop
 	const sync = createSync({ selected });
 	$effect(() => {
 		sync.selected(_selected, (v) => (_selected = v || options[0]));
 	});
 
-	/** Set the value from a parent */
-	export function set(option: CustomSelectOption<T> | null) {
-		if (!option) {
-			_selected = options[0];
-		} else {
-			_selected = option;
-		}
-	}
-
-	let selectedOption = $derived.by(() => options.find((o) => o.label === $selectedLabel));
+	// Get the whole option object
+	let selectedOption = $derived.by(
+		() => options.find((o) => o.label === $selectedLabel) || options[0]
+	);
 </script>
 
-<button
-	class="
-	flex
-	items-center
-	justify-between
-	gap-2
-	border-2
-	border-mineShaft-600
-	bg-transparent
-	pl-4
-	pr-3
-	font-medium
-	transition-opacity
-	hover:opacity-90
-	focus:outline-2
-	focus:outline-solar-500
-	focus-visible:border-transparent
-	focus-visible:outline
-	"
-	class:rounded-full={variant === 'pill'}
-	class:rounded-lg={variant === 'form'}
-	class:h-10={variant === 'pill'}
-	class:py-4={variant === 'form'}
-	use:melt={$trigger}
-	aria-label="{id}-label"
-	{id}
->
-	<div class="flex items-center">
-		{#if selectedOption?.image}
-			<img
-				src={selectedOption.image}
-				alt={selectedOption.label}
-				class="mr-2 size-5 object-contain"
-			/>
-		{/if}
-		{$selectedLabel || 'Select an option'}
-	</div>
-	<ChevronDown class="size-5 transition-transform duration-100 {$open ? 'rotate-180' : ''}" />
-</button>
+<SelectTrigger {variant} {id} {open} {trigger}>
+	{#if selectedOption.image && typeof selectedOption.image === 'string'}
+		<img src={selectedOption.image} alt={selectedOption.label} class="mr-2 size-5 object-contain" />
+	{/if}
+	{$selectedLabel || 'Select an option'}
+</SelectTrigger>
 
 {#if $open}
-	<div
-		class="
-		z-10
-		flex
-		max-h-[300px]
-		flex-col
-		overflow-y-auto
-		border-2
-		border-mineShaft-600
-		bg-shark-950
-		py-1
-		shadow
-		focus:!ring-0
-		"
-		class:px-1={variant === 'pill'}
-		class:px-2={variant === 'form'}
-		class:py-1={variant === 'pill'}
-		class:py-2={variant === 'form'}
-		class:rounded-2xl={variant === 'pill'}
-		class:rounded-lg={variant === 'form'}
-		use:melt={$menu}
-		transition:fade={{ duration: 100 }}
-	>
+	<SelectMenu {id} {variant} {menu} {open}>
 		{#each options as item}
-			<div
-				class="
-				relative
-				grid
-				cursor-pointer
-				grid-cols-[16px_1fr]
-				items-center
-				gap-2
-				rounded-xl
-				px-2
-				py-1
-				font-medium
-				hover:bg-solar-500
-				focus:z-10
-				focus:text-solar-950
-				data-[highlighted]:bg-solar-500
-				data-[highlighted]:text-solar-950
-				data-[disabled]:opacity-50
-				"
-				class:rounded-xl={variant === 'pill'}
-				class:rounded-sm={variant === 'form'}
-				use:melt={$option(item)}
-			>
-				{#if item.image}
-					<img src={item.image} alt={item.label} class="mr-2 size-4 object-contain" />
-				{:else}
-					<div class="check">
-						<Check class="size-4 {$isSelected(item.value) ? 'block' : 'hidden'}" />
-					</div>
-				{/if}
-				{item.label}
-			</div>
+			<SelectItem {id} {option} {variant} {item} {isSelected} />
 		{/each}
-	</div>
+	</SelectMenu>
 {/if}

--- a/src/lib/components/select/select.svelte
+++ b/src/lib/components/select/select.svelte
@@ -1,22 +1,23 @@
 <script lang="ts" context="module">
+	import { type SelectOption } from '@melt-ui/svelte';
 	export interface CustomSelectOption<T = unknown> extends SelectOption<T> {
 		image?: string;
 	}
 </script>
 
-<script lang="ts">
-	import { createSelect, createSync, melt, type SelectOption } from '@melt-ui/svelte';
+<script lang="ts" generics="T extends unknown">
+	import { createSelect, createSync, melt } from '@melt-ui/svelte';
 	import { fade } from 'svelte/transition';
 	import Check from 'lucide-svelte/icons/check';
 	import ChevronDown from 'lucide-svelte/icons/chevron-down';
 	import type { ChangeFn } from '@melt-ui/svelte/internal/helpers';
 
 	interface Props {
-		options: CustomSelectOption[];
-		selected: CustomSelectOption;
+		options: CustomSelectOption<T>[];
+		selected: CustomSelectOption<T>;
+		onSelectedChange?: ChangeFn<CustomSelectOption<T> | undefined>;
 		variant?: 'pill' | 'form';
 		id: string;
-		onSelectedChange?: ChangeFn<SelectOption | undefined>;
 		required?: boolean;
 		disabled?: boolean;
 		multiple?: boolean;
@@ -59,7 +60,7 @@
 	});
 
 	/** Set the value from a parent */
-	export function set(option: CustomSelectOption | null) {
+	export function set(option: CustomSelectOption<T> | null) {
 		if (!option) {
 			_selected = options[0];
 		} else {

--- a/src/lib/components/select/token.svelte
+++ b/src/lib/components/select/token.svelte
@@ -19,30 +19,33 @@
 	}: NetworkSelectProps = $props();
 
 	// Convert the options to the format the Select component expects
-	const balanceOptions: CustomSelectOption<TokenBalance>[] = $derived.by(() => {
-		return options.map((balance: TokenBalance) => {
+	// Using the index as the value instead of the TokenBalance object
+	const balanceOptions: CustomSelectOption<number>[] = $derived.by(() => {
+		return options.map((balance: TokenBalance, index) => {
 			return {
-				value: balance,
+				value: index,
 				label: `${String(balance.asset.symbol.code)} (${balance.asset.quantity})`,
 				image: balance.metadata.logo
 			};
 		});
 	});
 
-	// Create a derived store to get the selected option
-	let selectedOption: CustomSelectOption<TokenBalance> = $state({
-		value: _selected,
-		label: `${String(_selected.asset.symbol.code)} (${_selected.asset.quantity})`,
-		image: _selected.metadata.logo
+	// Create a store for the selected option
+	let selectedOption: CustomSelectOption<number> = $state({
+		value: 0,
+		label: `${String(options[0].asset.symbol.code)} (${options[0].asset.quantity})`,
+		image: options[0].metadata.logo
 	});
 
 	/** Set the value from a parent */
 	export function set(balance: TokenBalance | null) {
 		if (!balance) {
-			_selected = balanceOptions[0].value;
+			_selected = options[0];
 		} else {
 			_selected = balance;
-			const option = balanceOptions.find((o) => TokenBalance.from(o.value).equals(balance));
+			const option = balanceOptions.find((o) =>
+				TokenBalance.from(options[o.value]).equals(balance)
+			);
 			if (option) {
 				selectedOption = option;
 			}
@@ -50,8 +53,9 @@
 	}
 
 	// Sync the selected option with the passed in selected prop
+	// mapping the selected option to the index of the options array
 	$effect(() => {
-		const selected = options.find((o) => TokenBalance.from(o).equals(selectedOption.value));
+		const selected = options[selectedOption.value];
 		if (selected) {
 			_selected = selected;
 		}
@@ -70,9 +74,9 @@
 	<h3>Component State</h3>
 	<pre>
 
-_selected (store): {JSON.stringify(_selected)}
-selectedOption (store): {JSON.stringify(selectedOption)}
-options (store): {JSON.stringify(options)}
-balanceOptions (store): {JSON.stringify(balanceOptions)}
+_selected (store): {JSON.stringify(_selected, null, 2)}
+selectedOption (store): {JSON.stringify(selectedOption, null, 2)}
+options (store): {JSON.stringify(options, null, 2)}
+balanceOptions (store): {JSON.stringify(balanceOptions, null, 2)}
 </pre>
 {/if}

--- a/src/lib/components/select/token.svelte
+++ b/src/lib/components/select/token.svelte
@@ -1,34 +1,88 @@
 <script lang="ts">
 	import { TokenBalance } from '@wharfkit/common';
+	import { createSelect, type SelectOption } from '@melt-ui/svelte';
+	import { SelectTrigger, SelectMenu, SelectItem } from './elements';
+	import { writable } from 'svelte/store';
 
-	import Select, { type CustomSelectOption } from './select.svelte';
+	interface TokenSelectOption extends SelectOption<number> {
+		image?: string;
+	}
 
-	// Override the options and selected props to be more specific to the NetworkSelect component
 	interface Props {
 		options: TokenBalance[];
 		selected: TokenBalance;
 		debug?: boolean;
+		id: string;
+		disabled?: boolean;
+		required?: boolean;
+		multiple?: boolean;
+		sameWidth?: boolean;
 	}
 
-	let { selected: _selected = $bindable(), options, debug = false, ...props }: Props = $props();
+	let {
+		selected: _selected = $bindable(),
+		id,
+		options,
+		debug = false,
+		disabled = false,
+		required = false,
+		multiple = false,
+		sameWidth = true
+	}: Props = $props();
 
-	// Convert the options to the format the Select component expects
-	// Using the index as the value instead of the TokenBalance object
-	const balanceOptions: CustomSelectOption<number>[] = $derived.by(() => {
-		return options.map((balance: TokenBalance, index) => {
-			return {
-				value: index,
-				label: `${String(balance.asset.symbol.code)} (${balance.asset.quantity})`,
-				image: balance.metadata.logo
-			};
-		});
+	const variant = 'form';
+
+	const label = (balance: TokenBalance) =>
+		`${String(balance.asset.symbol.code)} (${balance.asset.quantity})`;
+
+	const image = (balance: TokenBalance) => balance.metadata.logo;
+
+	const createOption = (balance: TokenBalance, index: number): TokenSelectOption => {
+		return {
+			value: index,
+			label: label(balance),
+			image: image(balance)
+		};
+	};
+
+	// Convert the options to the format of SelectOption<number>
+	// Using an index as the value instead of the TokenBalance object
+	const balanceOptions: TokenSelectOption[] = options.map((balance: TokenBalance, index) =>
+		createOption(balance, index)
+	);
+
+	// Create a typed store for the selected option
+	let selectedTokenOption = writable<TokenSelectOption>(balanceOptions[0]);
+
+	// Build the select component with the custom store
+	const {
+		elements: { trigger, menu, option },
+		states: { open, selected, selectedLabel },
+		helpers: { isSelected }
+	} = createSelect({
+		selected: selectedTokenOption,
+		required,
+		disabled,
+		multiple,
+		forceVisible: true,
+		positioning: {
+			placement: 'bottom-start',
+			fitViewport: true,
+			sameWidth
+		}
 	});
 
-	// Create a store for the selected option
-	let selectedOption: CustomSelectOption<number> = $state({
-		value: 0,
-		label: `${String(options[0].asset.symbol.code)} (${options[0].asset.quantity})`,
-		image: options[0].metadata.logo
+	// Get the whole TokenBalance object from the selected option by index
+	let selectedTokenBalance = $derived.by(() => options[$selectedTokenOption.value] || options[0]);
+
+	// Get the image from the selected TokenBalance object
+	let selectedTokenImage = $derived(image(selectedTokenBalance));
+
+	// Sync the currently selected object with the bound selected prop
+	$effect(() => {
+		if (selected) {
+			_selected = selectedTokenBalance;
+		}
 	});
 
 	/** Set the value from a parent */
@@ -41,36 +95,33 @@
 				TokenBalance.from(options[o.value]).equals(balance)
 			);
 			if (option) {
-				selectedOption = option;
+				selectedTokenOption.set(option);
 			}
 		}
 	}
-
-	// Sync the selected option with the passed in selected prop
-	// mapping the selected option to the index of the options array
-	$effect(() => {
-		const selected = options[selectedOption.value];
-		if (selected) {
-			_selected = selected;
-		}
-	});
 </script>
 
-<Select
-	id="network-select"
-	variant="form"
-	bind:selected={selectedOption}
-	sameWidth={false}
-	options={balanceOptions}
-	{...props}
-/>
+<SelectTrigger {variant} {id} {open} {trigger}>
+	{#if selectedTokenImage}
+		<img src={selectedTokenImage} alt={$selectedLabel} class="mr-2 size-5 object-contain" />
+	{/if}
+	{$selectedLabel || 'Select an option'}
+</SelectTrigger>
+
+{#if $open}
+	<SelectMenu {id} {variant} {menu} {open}>
+		{#each balanceOptions as item}
+			<SelectItem {id} {option} {variant} {item} {isSelected} />
+		{/each}
+	</SelectMenu>
+{/if}
 
 {#if debug}
 	<h3>Component State</h3>
 	<pre>
 
 _selected (store): {JSON.stringify(_selected, null, 2)}
-selectedOption (store): {JSON.stringify(selectedOption, null, 2)}
+selectedOption (store): {JSON.stringify($selectedTokenOption, null, 2)}
 options (store): {JSON.stringify(options, null, 2)}
 balanceOptions (store): {JSON.stringify(balanceOptions, null, 2)}
 </pre>

--- a/src/lib/components/select/token.svelte
+++ b/src/lib/components/select/token.svelte
@@ -1,22 +1,16 @@
 <script lang="ts">
-	import type { ComponentProps } from 'svelte';
 	import { TokenBalance } from '@wharfkit/common';
 
 	import Select, { type CustomSelectOption } from './select.svelte';
 
 	// Override the options and selected props to be more specific to the NetworkSelect component
-	interface NetworkSelectProps extends Omit<ComponentProps<Select>, 'options' | 'selected'> {
+	interface Props {
 		options: TokenBalance[];
 		selected: TokenBalance;
 		debug?: boolean;
 	}
 
-	let {
-		selected: _selected = $bindable(),
-		options,
-		debug = false,
-		...props
-	}: NetworkSelectProps = $props();
+	let { selected: _selected = $bindable(), options, debug = false, ...props }: Props = $props();
 
 	// Convert the options to the format the Select component expects
 	// Using the index as the value instead of the TokenBalance object
@@ -63,6 +57,7 @@
 </script>
 
 <Select
+	id="network-select"
 	variant="form"
 	bind:selected={selectedOption}
 	sameWidth={false}

--- a/src/lib/components/select/types.d.ts
+++ b/src/lib/components/select/types.d.ts
@@ -1,0 +1,7 @@
+import { type SelectOption } from '@melt-ui/svelte';
+
+interface ExtendedSelectOption extends SelectOption {
+	image?: string;
+}
+
+export type SelectOptionVariant = 'pill' | 'form';

--- a/src/routes/[network]/(dev)/debug/components/sections/select.svelte
+++ b/src/routes/[network]/(dev)/debug/components/sections/select.svelte
@@ -1,19 +1,22 @@
 <script lang="ts">
 	import { Cluster, Stack } from '$lib/components/layout';
 	import Select from '$lib/components/select/select.svelte';
+	import type { ExtendedSelectOption } from '$lib/components/select/types';
 	import Label from '$lib/components/input/label.svelte';
 	import { Chains, TokenBalance, TokenIdentifier } from '@wharfkit/common';
 	import TokenSelect from '$lib/components/select/token.svelte';
+	import type { SelectOption } from '@melt-ui/svelte';
+	import Button from '$lib/components/button/button.svelte';
 
-	const options = [
+	const options: SelectOption[] = [
 		{ value: 30, label: '30d' },
 		{ value: 60, label: '60d' },
 		{ value: 90, label: '90d' },
 		{ value: 365, label: '365d' }
 	];
-	let selected = $state(options[1]);
+	let selected = $state(options[0]);
 
-	const formOptions = [
+	const formOptions: SelectOption[] = [
 		{ value: 30, label: '30d' },
 		{ value: 60, label: '60d' },
 		{ value: 90, label: '90d' },
@@ -21,7 +24,7 @@
 	];
 	let selectedFormOption = $state(formOptions[1]);
 
-	const imageOptions = [
+	const imageOptions: ExtendedSelectOption[] = [
 		{ value: Chains.EOS.id, label: Chains.EOS.name, image: String(Chains.EOS.getLogo()) },
 		{
 			value: Chains.Jungle4.id,
@@ -80,6 +83,7 @@
 				<Select id="date-range" {options} bind:selected />
 			</Stack>
 			<span>Value in parent: {selected.label}</span>
+			<Button onclick={() => (selected = options[2])}>Test set to 90d</Button>
 		</Cluster>
 	</Stack>
 

--- a/src/routes/[network]/(dev)/debug/components/summaries/eosio/buyrambytes.svelte
+++ b/src/routes/[network]/(dev)/debug/components/summaries/eosio/buyrambytes.svelte
@@ -1,4 +1,3 @@
-
 <script>
 	import * as SystemContract from '$lib/wharf/contracts/system';
 	import Code from '$lib/components/code.svelte';


### PR DESCRIPTION
Fixes type errors and refactors the token select to use an index vs the `tokenbalance` object

Note: generics across components is not well supported. Couldn't get it to work well, so the solution is twofold: 
1) either leave the type of the value key in the options array to be implicitly typed (e.g. `options: SelectOption[]` or `options: ExtendedSelectOption[]` instead of `options: SelectOption<number>[]`, see the examples in the debug page)
2) or, if you're passing in an array of objects that don't extend the `SelectOption` interface - create a custom writable store in the new select component which is typed to the object (e.g. the `TokenSelect` component takes `options: TokenBalance[]` and would implement `writable<TokenBalance>()` for the store. Note: in this case there is a step to make the object an index, so the actual store is `writable<TokenSelectOption>()` but other implementations should be simpler.)