### PR TITLE
chore: add install package command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,8 +16,18 @@ check: node_modules
 format: node_modules
 	bun run format
 
-node_modules:
-	bun install --yarn
+.PHONY: install
+install:
+	@if [ -z "$(package)" ]; then \
+		echo "Installing all dependencies:"; \
+		bun install --yarn; \
+	else \
+		echo "Installing package: $(package)"; \
+		bun install --yarn $(package); \
+	fi
+
+%:
+	$(MAKE) install package=$*
 
 codegen:
 	npx @wharfkit/cli generate -u $(API_EOS_CHAIN) -f src/lib/wharf/contracts/system.ts eosio


### PR DESCRIPTION
Now when installing packages if you use `make install package_name` it will run `bun install --yarn package_name` and keep the lockfile in sync