### PR TITLE
Settings page styles

### DIFF
--- a/src/lib/components/input/switch.svelte
+++ b/src/lib/components/input/switch.svelte
@@ -47,54 +47,35 @@
 		use:melt={$root}
 		class="
 		relative
-		h-5
+		h-8
+		w-[52px]
 		rounded-full
-		border
-		border-mineShaft-700
+		border-2
+		border-mineShaft-600
 		bg-transparent
+		*:size-4
+		*:translate-x-1.5
+		*:bg-mineShaft-400
+		*:transition-transform
 		focus-visible:border-solar-500
 		focus-visible:outline
 		focus-visible:outline-2
 		focus-visible:outline-offset-[-2px]
 		focus-visible:outline-solar-500
 		disabled:cursor-not-allowed
-		disabled:bg-mineShaft-700
+		disabled:opacity-40
 		data-[state=checked]:border-skyBlue-500
 		data-[state=checked]:bg-skyBlue-500
+		*:data-[state=checked]:translate-x-[26px]
+		*:data-[state=checked]:scale-150
+		*:data-[state=checked]:bg-skyBlue-50
 		data-[state=checked]:hover:border-skyBlue-400
 		data-[state=checked]:hover:bg-skyBlue-400
-		data-[state=checked]:disabled:border-mineShaft-950
-		data-[state=checked]:disabled:bg-mineShaft-950
 "
 		{id}
 		aria-labelledby={ariaLabelledBy}
 	>
-		<span class="thumb block rounded-full bg-mineShaft-200 transition"></span>
+		<span class="thumb block rounded-full"></span>
 	</button>
 	<input use:melt={$input} />
 </div>
-
-<style>
-	button {
-		/* Width of the track */
-		--w: 36px;
-		width: var(--w);
-	}
-
-	.thumb {
-		/* Size of the thumb */
-		--size: 16px;
-		width: var(--size);
-		height: var(--size);
-		transform: translateX(1px);
-	}
-
-	:global([data-state='checked']) .thumb {
-		transform: translateX(calc(var(--w) - (var(--size) + 3px)));
-		background-color: white;
-	}
-
-	:global(button[data-disabled='true']) .thumb {
-		background-color: theme('colors.mineShaft.300');
-	}
-</style>

--- a/src/routes/[network]/(dev)/debug/components/sections/inputs.svelte
+++ b/src/routes/[network]/(dev)/debug/components/sections/inputs.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { Stack } from '$lib/components/layout';
+	import { Cluster, Stack } from '$lib/components/layout';
 	import TextInput from '$lib/components/input/text.svelte';
 	import Label from '$lib/components/input/label.svelte';
 	import AssetOrUnitsInput from '$lib/components/input/assetOrUnits.svelte';
@@ -69,17 +69,23 @@
 			<h2 class="h2">Switch</h2>
 
 			<Stack>
-				<Label for="mySwitch-1">Default</Label>
-				<Switch id="mySwitch-1" name="mySwitch-1" checked={false} />
+				<h3 class="h4">Default</h3>
+				<Cluster>
+					<Switch id="mySwitch-1" name="mySwitch-1" checked={false} />
+					<Switch id="mySwitch-1" name="mySwitch-1" checked={true} />
+				</Cluster>
 			</Stack>
 
 			<Stack>
-				<Label for="mySwitch-2">Disabled</Label>
-				<Switch id="mySwitch-2" name="mySwitch-2" disabled checked />
+				<h3 class="h4">Disabled</h3>
+				<Cluster>
+					<Switch id="mySwitch-2" name="mySwitch-2" disabled checked={false} />
+					<Switch id="mySwitch-2" name="mySwitch-2" disabled checked />
+				</Cluster>
 			</Stack>
 
 			<Stack>
-				<Label for="mySwitch-3">Checked</Label>
+				<h3 class="h4">Controlled</h3>
 				<Switch id="mySwitch-3" name="mySwitch-3" bind:checked={controlledSwitch} />
 				<p>Switch is {controlledSwitch ? 'on' : 'off'}</p>
 			</Stack>

--- a/src/routes/[network]/settings/+page.svelte
+++ b/src/routes/[network]/settings/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import Checkbox from '$lib/components/input/checkbox.svelte';
+	import Switch from '$lib/components/input/switch.svelte';
 	import Stack from '$lib/components/layout/stack.svelte';
 	import Pageheader from '$lib/components/pageheader.svelte';
 	import LanguageSelect from '$lib/components/select/language.svelte';
@@ -16,23 +16,25 @@
 	});
 </script>
 
-<Stack>
+<Stack class="">
 	<Pageheader title="Settings" subtitle="Configure Unicove" />
 
-	<div>
-		<Label for="language-select">Language Selector</Label>
-		<LanguageSelect />
-	</div>
-
-	<div>
-		<Label for="advanced-mode">Enable Advanced Mode</Label>
-		<Checkbox id="advanced-mode" bind:checked={advancedMode.value} />
-	</div>
-
-	{#if advancedMode.value}
-		<div>
-			<Label for="debug-mode">Enable Debug Mode</Label>
-			<Checkbox id="debug-mode" bind:checked={debugMode.value} />
+	<div class="grid max-w-screen-sm auto-rows-fr gap-4">
+		<div class="flex items-center justify-between">
+			<Label for="language-select">Language Selector</Label>
+			<LanguageSelect />
 		</div>
-	{/if}
+
+		<div class="flex items-center justify-between">
+			<Label for="advanced-mode">Enable Advanced Mode</Label>
+			<Switch id="advanced-mode" bind:checked={advancedMode.value} />
+		</div>
+
+		{#if advancedMode.value}
+			<div class="flex items-center justify-between">
+				<Label for="debug-mode">Enable Debug Mode</Label>
+				<Switch id="debug-mode" bind:checked={debugMode.value} />
+			</div>
+		{/if}
+	</div>
 </Stack>


### PR DESCRIPTION
Adds some styles to settings page.

Refactors switch component styling: 
- exclusively uses tailwind (no additional css transferred over the wire)
- enhances the usability on mobile and overall accessibility with increased sizing