### PR TITLE
enhancement: preload chain logo

### DIFF
--- a/src/lib/components/accountswitch.svelte
+++ b/src/lib/components/accountswitch.svelte
@@ -65,6 +65,10 @@
 	let logo = $derived(chainLogos.get(String(context.wharf.session?.chain.id)) || '');
 </script>
 
+<svelte:head>
+	<link rel="preload" href={String(logo)} as="image" type="image/png" />
+</svelte:head>
+
 <!-- [@media(any-hover:hover)]:hover:opacity-80 -->
 
 <!-- Trigger Button -->

--- a/src/lib/components/pageheader.svelte
+++ b/src/lib/components/pageheader.svelte
@@ -24,6 +24,10 @@
 	let logo = $derived(chainLogos.get(String(props.network.chain.id)) || '');
 </script>
 
+<svelte:head>
+	<link rel="preload" href={String(logo)} as="image" type="image/png" />
+</svelte:head>
+
 <header class="col-span-full flex min-h-16 items-center gap-4">
 	{#if props.backPath}
 		<button


### PR DESCRIPTION
Preload the chain logo in pageheader and account switcher. This will instruct the browser to prioritize this image which should reduce pop-in