### PR TITLE
feat: include stale-while-revalidate to cache-control

### DIFF
--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -15,7 +15,7 @@ export function calculateValue(balance: Asset, currency: Asset): Asset {
 
 export function getCacheHeaders(ttl: number, irreversible: boolean = false) {
 	// Maintain a ttl cache by default
-	let browser = `public, max-age=${ttl}, s-max-age=${ttl}`;
+	let browser = `public, max-age=${ttl}, s-max-age=${ttl}, stale-while-revalidate=${ttl}`;
 	let cloudflare = `max-age=${ttl}, s-max-age=${ttl}`;
 
 	// If the data is irreversible, set 1 year and immutable


### PR DESCRIPTION
adding `stale-while-revalidate` could be very useful. Someone makes the request at 5.01 seconds and the cache is stale, so cloudflare can serve them that stale cache and revalidate it for the person that hits the same route at 5.02 seconds.