### PR TITLE
feat: copy account name button

### DIFF
--- a/src/lib/components/button/copy.svelte
+++ b/src/lib/components/button/copy.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
 	import { getSetting } from '$lib/state/settings.svelte';
 	import Copy from 'lucide-svelte/icons/copy';
+	import { quartOut, sineIn } from 'svelte/easing';
+	import { fade, fly } from 'svelte/transition';
 
 	interface Props {
 		data: string;
@@ -10,21 +12,34 @@
 
 	let props: Props = $props();
 
+	let hint = $state(false);
+
 	async function copyToClipboard() {
 		try {
 			await navigator.clipboard.writeText(props.data);
 			if (debugMode) console.log(props.data, 'copied to clipboard');
+			hint = true;
+			setTimeout(() => (hint = false), 500);
 		} catch (err) {
 			if (debugMode) console.error('Failed to copy text: ', err);
 		}
 	}
 </script>
 
-<!-- Styled specifically for the PageHeader component  -->
+<!-- Styled specifically for the PageHeader component. Will need to change it for more generic use.  -->
 <!-- Uses absolute positioning so it can maintain a decent hit slop on mobile without affecting layout -->
 <button
 	onclick={copyToClipboard}
-	class="absolute right-0 grid size-12 translate-x-10 translate-y-1 place-items-center text-skyBlue-500 hover:text-skyBlue-400 focus-visible:text-solar-500 focus-visible:outline-none"
+	class="absolute left-full grid size-12 -translate-x-2 translate-y-1 place-items-center gap-2 text-skyBlue-500 hover:text-skyBlue-400 focus-visible:text-skyBlue-400 focus-visible:outline-none active:text-skyBlue-200"
 >
-	<Copy class="size-4 " />
+	<div class="relative">
+		<Copy class="size-4 " />
+		{#if hint}
+			<span
+				in:fly={{ x: -20, easing: quartOut }}
+				out:fade={{ easing: sineIn }}
+				class="absolute inset-y-0 left-full translate-x-2 text-xs text-skyBlue-400">Copied!</span
+			>
+		{/if}
+	</div>
 </button>

--- a/src/lib/components/button/copy.svelte
+++ b/src/lib/components/button/copy.svelte
@@ -1,0 +1,30 @@
+<script lang="ts">
+	import { getSetting } from '$lib/state/settings.svelte';
+	import Copy from 'lucide-svelte/icons/copy';
+
+	interface Props {
+		data: string;
+	}
+
+	let { value: debugMode } = getSetting('debug-mode', false);
+
+	let props: Props = $props();
+
+	async function copyToClipboard() {
+		try {
+			await navigator.clipboard.writeText(props.data);
+			if (debugMode) console.log(props.data, 'copied to clipboard');
+		} catch (err) {
+			if (debugMode) console.error('Failed to copy text: ', err);
+		}
+	}
+</script>
+
+<!-- Styled specifically for the PageHeader component  -->
+<!-- Uses absolute positioning so it can maintain a decent hit slop on mobile without affecting layout -->
+<button
+	onclick={copyToClipboard}
+	class="absolute right-0 grid size-12 translate-x-10 translate-y-1 place-items-center text-skyBlue-500 hover:text-skyBlue-400 focus-visible:text-solar-500 focus-visible:outline-none"
+>
+	<Copy class="size-4 " />
+</button>

--- a/src/lib/components/button/copy.svelte
+++ b/src/lib/components/button/copy.svelte
@@ -3,6 +3,7 @@
 	import Copy from 'lucide-svelte/icons/copy';
 	import { quadIn, quartOut } from 'svelte/easing';
 	import { fade, fly } from 'svelte/transition';
+	import { browser } from '$app/environment';
 
 	interface Props {
 		data: string;
@@ -28,7 +29,7 @@
 
 <!-- Styled specifically for the PageHeader component. Will need to change it for more generic use.  -->
 <!-- Uses absolute positioning so it can maintain a decent hit slop on mobile without affecting layout -->
-{#if 'clipboard' in navigator}
+{#if browser && 'clipboard' in navigator}
 	<button
 		onclick={copyToClipboard}
 		class="absolute left-full grid size-12 -translate-x-2 translate-y-1 place-items-center gap-2 text-skyBlue-500 hover:text-skyBlue-400 focus-visible:text-skyBlue-400 focus-visible:outline-none active:scale-95"

--- a/src/lib/components/button/copy.svelte
+++ b/src/lib/components/button/copy.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { getSetting } from '$lib/state/settings.svelte';
 	import Copy from 'lucide-svelte/icons/copy';
-	import { quartOut, sineIn } from 'svelte/easing';
+	import { quadIn, quartOut } from 'svelte/easing';
 	import { fade, fly } from 'svelte/transition';
 
 	interface Props {
@@ -19,7 +19,7 @@
 			await navigator.clipboard.writeText(props.data);
 			if (debugMode) console.log(props.data, 'copied to clipboard');
 			hint = true;
-			setTimeout(() => (hint = false), 500);
+			setTimeout(() => (hint = false), 300);
 		} catch (err) {
 			if (debugMode) console.error('Failed to copy text: ', err);
 		}
@@ -31,14 +31,14 @@
 {#if 'clipboard' in navigator}
 	<button
 		onclick={copyToClipboard}
-		class="absolute left-full grid size-12 -translate-x-2 translate-y-1 place-items-center gap-2 text-skyBlue-500 hover:text-skyBlue-400 focus-visible:text-skyBlue-400 focus-visible:outline-none active:text-skyBlue-200"
+		class="absolute left-full grid size-12 -translate-x-2 translate-y-1 place-items-center gap-2 text-skyBlue-500 hover:text-skyBlue-400 focus-visible:text-skyBlue-400 focus-visible:outline-none active:scale-95"
 	>
 		<div class="relative">
 			<Copy class="size-4 " />
 			{#if hint}
 				<span
-					in:fly={{ x: -20, easing: quartOut }}
-					out:fade={{ easing: sineIn }}
+					in:fly={{ x: -20, easing: quartOut, duration: 100 }}
+					out:fade={{ easing: quadIn, duration: 200 }}
 					class="absolute inset-y-0 left-full translate-x-2 text-xs text-skyBlue-400">Copied!</span
 				>
 			{/if}

--- a/src/lib/components/button/copy.svelte
+++ b/src/lib/components/button/copy.svelte
@@ -28,18 +28,20 @@
 
 <!-- Styled specifically for the PageHeader component. Will need to change it for more generic use.  -->
 <!-- Uses absolute positioning so it can maintain a decent hit slop on mobile without affecting layout -->
-<button
-	onclick={copyToClipboard}
-	class="absolute left-full grid size-12 -translate-x-2 translate-y-1 place-items-center gap-2 text-skyBlue-500 hover:text-skyBlue-400 focus-visible:text-skyBlue-400 focus-visible:outline-none active:text-skyBlue-200"
->
-	<div class="relative">
-		<Copy class="size-4 " />
-		{#if hint}
-			<span
-				in:fly={{ x: -20, easing: quartOut }}
-				out:fade={{ easing: sineIn }}
-				class="absolute inset-y-0 left-full translate-x-2 text-xs text-skyBlue-400">Copied!</span
-			>
-		{/if}
-	</div>
-</button>
+{#if 'clipboard' in navigator}
+	<button
+		onclick={copyToClipboard}
+		class="absolute left-full grid size-12 -translate-x-2 translate-y-1 place-items-center gap-2 text-skyBlue-500 hover:text-skyBlue-400 focus-visible:text-skyBlue-400 focus-visible:outline-none active:text-skyBlue-200"
+	>
+		<div class="relative">
+			<Copy class="size-4 " />
+			{#if hint}
+				<span
+					in:fly={{ x: -20, easing: quartOut }}
+					out:fade={{ easing: sineIn }}
+					class="absolute inset-y-0 left-full translate-x-2 text-xs text-skyBlue-400">Copied!</span
+				>
+			{/if}
+		</div>
+	</button>
+{/if}

--- a/src/lib/components/pageheader.svelte
+++ b/src/lib/components/pageheader.svelte
@@ -3,6 +3,8 @@
 	import { chainLogos } from '@wharfkit/common';
 	import { goto } from '$app/navigation';
 	import { type NetworkState } from '$lib/state/network.svelte';
+	import { page } from '$app/stores';
+	import CopyButton from '$lib/components/button/copy.svelte';
 
 	interface Props {
 		title: string;
@@ -22,6 +24,8 @@
 	}
 
 	let logo = $derived(chainLogos.get(String(props.network.chain.id)) || '');
+
+	let routePath = $derived($page.url.pathname.split('/')[3]);
 </script>
 
 <svelte:head>
@@ -47,7 +51,12 @@
 	{/if}
 
 	<div class="grid gap-2">
-		<h1 class="text-3xl font-bold leading-none text-white">{props.title}</h1>
+		<h1 class="relative flex w-fit items-center text-3xl font-bold leading-none text-white">
+			<span>{props.title}</span>
+			{#if routePath === 'account'}
+				<CopyButton data={props.title} />
+			{/if}
+		</h1>
 		{#if props.subtitle}
 			<p class="text-muted text-base leading-none">{props.subtitle}</p>
 		{/if}


### PR DESCRIPTION
Adds a button to copy the account name from the page header