### PR TITLE
Logo updates

### DIFF
--- a/src/lib/components/accountswitch.svelte
+++ b/src/lib/components/accountswitch.svelte
@@ -69,10 +69,6 @@
 	let logo = $derived(chainLogos.get(String(context.wharf.session?.chain.id)) || '');
 </script>
 
-<svelte:head>
-	<link rel="preload" href={String(logo)} as="image" type="image/png" />
-</svelte:head>
-
 <!-- [@media(any-hover:hover)]:hover:opacity-80 -->
 
 <!-- Trigger Button -->

--- a/src/lib/components/pageheader.svelte
+++ b/src/lib/components/pageheader.svelte
@@ -24,10 +24,6 @@
 	let logo = $derived(chainLogos.get(String(props.network.chain.id)) || '');
 </script>
 
-<svelte:head>
-	<link rel="preload" href={String(logo)} as="image" type="image/png" />
-</svelte:head>
-
 <header class="col-span-full flex min-h-16 items-center gap-4">
 	{#if props.backPath}
 		<button

--- a/src/routes/[network]/(homepage)/(wallets)/metamask/+page.svelte
+++ b/src/routes/[network]/(homepage)/(wallets)/metamask/+page.svelte
@@ -6,13 +6,13 @@
 	import Button from '$lib/components/button/button.svelte';
 	import Box from '$lib/components/layout/box/box.svelte';
 	import { checkForSnap, requestSnap } from '$lib/metamask-snap';
-	import EOS from '$lib/assets/EOS@2x.svg';
 	import Metamask from '$lib/assets/metamask.svg';
 	import { MetaMaskState } from '$lib/state/metamask.svelte';
 	import type { UnicoveContext } from '$lib/state/client.svelte.js';
 	import { Cluster, Stack } from '$lib/components/layout/index.js';
 	import { accountCreationPluginMetamask } from '$lib/state/client/wharf.svelte';
 	import { getSetting } from '$lib/state/settings.svelte';
+	import { chainLogos } from '@wharfkit/common';
 
 	const { data } = $props();
 	const context = getContext<UnicoveContext>('state');
@@ -92,6 +92,8 @@
 			walletPlugin: 'wallet-plugin-metamask'
 		});
 	}
+
+	const EOS = String(chainLogos.get(String(data.network.chain.id)));
 </script>
 
 <section class="col-span-full @container">
@@ -127,7 +129,11 @@
 				<svg width="36" height="36" fill="none" xmlns="http://www.w3.org/2000/svg">
 					<path d="M18.008 0v36M36.008 18h-36" stroke="#fff" />
 				</svg>
-				<img class="h-40 rounded-full bg-mineShaft-950 px-2 py-4" src={EOS} alt="eos" />
+				<img
+					class="h-40 rounded-full bg-mineShaft-950 object-contain px-2 py-4"
+					src={EOS}
+					alt="eos"
+				/>
 			</div>
 		</div>
 

--- a/src/routes/[network]/(homepage)/(wallets)/metamask/+page.svelte
+++ b/src/routes/[network]/(homepage)/(wallets)/metamask/+page.svelte
@@ -93,7 +93,8 @@
 		});
 	}
 
-	const EOS = String(chainLogos.get(String(data.network.chain.id)));
+	const networkLogo = String(chainLogos.get(String(data.network.chain.id)));
+	const networkName = data.network.chain.name;
 </script>
 
 <section class="col-span-full @container">
@@ -131,8 +132,8 @@
 				</svg>
 				<img
 					class="h-40 rounded-full bg-mineShaft-950 object-contain px-2 py-4"
-					src={EOS}
-					alt="eos"
+					src={networkLogo}
+					alt={networkName}
 				/>
 			</div>
 		</div>

--- a/src/routes/[network]/(homepage)/+page.svelte
+++ b/src/routes/[network]/(homepage)/+page.svelte
@@ -24,6 +24,7 @@
 	let tokenPrices: HistoricalPrice[] = $state([]);
 
 	let networkLogo = $derived(String(chainLogos.get(data.network?.chain.id.toString())));
+	let networkName = $derived(String(data.network.chain.name));
 
 	// async function loadPrices() {
 	// 	const ramResponse: Response = await fetch(`/${data.network}/api/metrics/marketprice/ram`);
@@ -87,10 +88,10 @@
 			class="z-10 col-span-full col-start-1 row-start-1 items-start xs:col-span-3 xs:col-start-1 sm:col-span-3 sm:col-start-1 sm:row-start-1 sm:max-w-sm sm:place-self-center md:col-span-6 md:col-start-1 md:max-w-xl md:place-self-auto"
 		>
 			<h1 class="text-balance text-3xl font-semibold leading-tight md:text-4xl md:leading-tight">
-				Unicove is your gateway to the {data.network.chain.name} Network
+				Unicove is your gateway to the {networkName} Network
 			</h1>
 			<p class="text-muted mb-2 text-balance text-xl leading-tight md:text-2xl md:leading-tight">
-				Stake, Send, Manage Tokens, and Explore EOS – all with ease
+				Stake, Send, Manage Tokens, and Explore {networkName} – all with ease
 			</p>
 			<!-- <Button href={`/${data.network}/signup`}>Create your EOS account now</Button> -->
 			<!-- <Button disabled>Create your EOS account (Coming Soon)</Button> -->
@@ -100,7 +101,7 @@
 		<div
 			class="relative left-12 top-8 z-10 col-span-full col-start-3 row-start-1 hidden max-h-80 justify-self-center xs:block sm:col-start-3 md:inset-0 md:col-span-3 md:col-start-7 xl:col-span-4 xl:col-start-6"
 		>
-			<img class="h-40 object-contain md:h-72" src={networkLogo} alt="eos" />
+			<img class="h-40 object-contain md:h-72" src={networkLogo} alt={networkName} />
 		</div>
 
 		<!-- Unicove logo outline -->
@@ -162,15 +163,15 @@
 					</svg>
 					<img
 						class="h-40 rounded-full bg-mineShaft-950 object-contain px-2 py-4"
-						src={String(chainLogos.get(String(Chains.EOS.id)))}
-						alt="eos"
+						src={networkLogo}
+						alt={networkName}
 					/>
 				</div>
 			</div>
 
 			<Box class="grid place-items-center py-8">
 				{@render textblock({
-					title: 'Metamask is now EOS compatible',
+					title: `Metamask is now ${networkName} compatible`,
 					text: 'TODO: The APR is an estimate, and may fluctuate based on how many and much others are staking. Your 21 day lockup period starts when you unstake your EOS. You will always get back your staked EOS.',
 					button: {
 						text: 'Get a free account',

--- a/src/routes/[network]/(homepage)/+page.svelte
+++ b/src/routes/[network]/(homepage)/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { Box, Card, Stack, Subgrid, Switcher } from '$lib/components/layout';
 	import Button from '$lib/components/button/button.svelte';
-	import EOS from '$lib/assets/EOS@2x.svg';
+	import { chainLogos, Chains } from '@wharfkit/common';
 	import Metamask from '$lib/assets/metamask.svg';
 	import EOSPriceHistory from '$lib/components/chart/eospricehistory.svelte';
 	import RamPriceHistory from '$lib/components/chart/rampricehistory.svelte';
@@ -22,6 +22,8 @@
 
 	let ramPrices: HistoricalPrice[] = $state([]);
 	let tokenPrices: HistoricalPrice[] = $state([]);
+
+	let networkLogo = $derived(String(chainLogos.get(data.network?.chain.id.toString())));
 
 	// async function loadPrices() {
 	// 	const ramResponse: Response = await fetch(`/${data.network}/api/metrics/marketprice/ram`);
@@ -85,7 +87,7 @@
 			class="z-10 col-span-full col-start-1 row-start-1 items-start xs:col-span-3 xs:col-start-1 sm:col-span-3 sm:col-start-1 sm:row-start-1 sm:max-w-sm sm:place-self-center md:col-span-6 md:col-start-1 md:max-w-xl md:place-self-auto"
 		>
 			<h1 class="text-balance text-3xl font-semibold leading-tight md:text-4xl md:leading-tight">
-				Unicove is your gateway to the EOS Network
+				Unicove is your gateway to the {data.network.chain.name} Network
 			</h1>
 			<p class="text-muted mb-2 text-balance text-xl leading-tight md:text-2xl md:leading-tight">
 				Stake, Send, Manage Tokens, and Explore EOS – all with ease
@@ -98,7 +100,7 @@
 		<div
 			class="relative left-12 top-8 z-10 col-span-full col-start-3 row-start-1 hidden max-h-80 justify-self-center xs:block sm:col-start-3 md:inset-0 md:col-span-3 md:col-start-7 xl:col-span-4 xl:col-start-6"
 		>
-			<img class="h-40 object-contain md:h-72" src={EOS} alt="eos" />
+			<img class="h-40 object-contain md:h-72" src={networkLogo} alt="eos" />
 		</div>
 
 		<!-- Unicove logo outline -->
@@ -158,7 +160,11 @@
 					<svg width="36" height="36" fill="none" xmlns="http://www.w3.org/2000/svg">
 						<path d="M18.008 0v36M36.008 18h-36" stroke="#fff" />
 					</svg>
-					<img class="h-40 rounded-full bg-mineShaft-950 px-2 py-4" src={EOS} alt="eos" />
+					<img
+						class="h-40 rounded-full bg-mineShaft-950 object-contain px-2 py-4"
+						src={String(chainLogos.get(String(Chains.EOS.id)))}
+						alt="eos"
+					/>
 				</div>
 			</div>
 

--- a/src/routes/[network]/(homepage)/components/tlvhex.svelte
+++ b/src/routes/[network]/(homepage)/components/tlvhex.svelte
@@ -6,6 +6,7 @@
 	const { network } = getContext<UnicoveContext>('state');
 
 	let networkLogo = $derived(String(chainLogos.get(network?.chain.id.toString() || '')));
+	let networkName = $derived(String(network?.chain.name));
 
 	const { TLV, APR } = $props();
 </script>
@@ -27,7 +28,7 @@
 			/>
 		</svg>
 		<div class="grid text-center uppercase">
-			<img class="mb-4 h-12 place-self-center md:h-20" src={networkLogo} alt="eos" />
+			<img class="mb-4 h-12 place-self-center md:h-20" src={networkLogo} alt={networkName} />
 			<span class="text-sm text-white/60 md:text-lg">Total locked value</span>
 			<!-- TODO: add eos formatter -->
 			<span class="text-md font-semibold md:text-2xl">{TLV} EOS</span>

--- a/src/routes/[network]/(homepage)/components/tlvhex.svelte
+++ b/src/routes/[network]/(homepage)/components/tlvhex.svelte
@@ -1,5 +1,11 @@
 <script lang="ts">
-	import EOS from '$lib/assets/EOS@2x.svg';
+	import { type UnicoveContext } from '$lib/state/client.svelte';
+	import { chainLogos } from '@wharfkit/common';
+	import { getContext } from 'svelte';
+
+	const { network } = getContext<UnicoveContext>('state');
+
+	let networkLogo = $derived(String(chainLogos.get(network?.chain.id.toString() || '')));
 
 	const { TLV, APR } = $props();
 </script>
@@ -21,7 +27,7 @@
 			/>
 		</svg>
 		<div class="grid text-center uppercase">
-			<img class="mb-4 h-12 place-self-center md:h-20" src={EOS} alt="eos" />
+			<img class="mb-4 h-12 place-self-center md:h-20" src={networkLogo} alt="eos" />
 			<span class="text-sm text-white/60 md:text-lg">Total locked value</span>
 			<!-- TODO: add eos formatter -->
 			<span class="text-md font-semibold md:text-2xl">{TLV} EOS</span>

--- a/src/routes/[network]/+layout.svelte
+++ b/src/routes/[network]/+layout.svelte
@@ -8,6 +8,7 @@
 	import UnicoveLogo from '$lib/assets/unicovelogo.svelte';
 	import Search from '$lib/components/input/search.svelte';
 	import X from 'lucide-svelte/icons/circle-x';
+	import { chainLogos } from '@wharfkit/common';
 
 	let { children, data } = $props();
 
@@ -83,7 +84,21 @@
 		// set the flag to prevent banner showing on next load
 		localStorage.setItem('hide-v1-banner', 'true');
 	}
+
+	// Deduplicate chain logos
+	let logoSet = Array.from(new Set(chainLogos.values())).map(String);
 </script>
+
+<!-- Preload current chain logo, prefetch the rest to avoid future pop-in -->
+<svelte:head>
+	{#each logoSet as logoSrc}
+		{#if logoSrc === chainLogos.get(String(data.network.chain.id))}
+			<link rel="preload" href={logoSrc} as="image" type="image/png" />
+		{:else}
+			<link rel="prefetch" href={logoSrc} as="image" type="image/png" />
+		{/if}
+	{/each}
+</svelte:head>
 
 {#if showBanner}
 	<aside


### PR DESCRIPTION
- Use the current network logo on homepage (e.g. Jungle 4, EOS)
- Refactor preloading to happen in layout instead of components
- Preload current chain logo, prefetch the others
- Use the `chainLogos` version of the EOS logo elsewhere to take advantage of the cached image